### PR TITLE
Cleanup and add energy sensors

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -108,7 +108,7 @@ class Iotawatt:
             _LOGGER.debug("Out: Name: %s", channel_name)
 
             channel_output_name = "output_" + str(channel_name)
-            channel_unit = query['series'][i]['unit']
+            channel_unit = outputs[i]['units']
             self._createOrUpdateSensorSet(sensors, channel_output_name, "N/A", channel_name, "Output", channel_unit)
 
         # Update all entities, query depending on Unit

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -63,7 +63,7 @@ class Iotawatt:
     def _createOrUpdateSensor(self, sensors, entity, channel_nbr, name, type, unit):
         if entity not in sensors:
             _LOGGER.debug("%s: Creating Channel sensor %s", type, entity)
-            sensors[entity] = Sensor(channel_nbr, name, type, unit, None, self._macAddress)
+            sensors[entity] = Sensor(channel_nbr, name, type, unit, None, None, self._macAddress)
         else:
             sensor = sensors[entity]
             sensor.setName(name)
@@ -143,6 +143,7 @@ class Iotawatt:
         for idx in range(len(integrated_query_names)):
             sensor = sensors[integrated_query_entities[idx]]
             sensor.setValue(values[0][idx+1])
+            sensor.setBegin(values[0][0])
 
 
     async def _getQueryShowSeries(self):

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -76,31 +76,33 @@ class Iotawatt:
         _LOGGER.debug("Query: %s", query)
 
         for i in range(len(inputs)):
-            channel_name = inputs[i]['channel']
-            _LOGGER.debug("In: Channel: %s - Name: %s", channel_name, query['series'][i]['name'])
+            channel_nbr = inputs[i]['channel']
+            _LOGGER.debug("In: Channel: %s - Name: %s", channel_nbr, query['series'][i]['name'])
 
-            channel_input_name = "input_" + str(channel_name)
+            channel_input_name = "input_" + str(channel_nbr)
+            channel_unit = query['series'][i]['unit']
             if channel_input_name not in sensors:
                 # Sensor doesn't exist yet, create it.
                 _LOGGER.debug("In: Creating Channel sensor %s", channel_input_name)
-                sensors[channel_input_name] = Sensor(channel_name, query['series'][i]['name'], "Input", query['series'][i]['unit'], None, self._macAddress)
+                sensors[channel_input_name] = Sensor(channel_nbr, query['series'][i]['name'], "Input", channel_unit, None, self._macAddress)
             else:
                 inputsensor = sensors[channel_input_name]
                 inputsensor.setName(query['series'][i]['name'])
-                inputsensor.setUnit(query['series'][i]['unit'])
+                inputsensor.setUnit(channel_unit)
                 inputsensor.setSensorID(self._macAddress)
 
         for i in range(len(outputs)):
-            channel_name = inputs[i]['channel']
-            _LOGGER.debug("Out: Name: %s", outputs[i]['name'])
+            channel_name = str(outputs[i]['name'])
+            _LOGGER.debug("Out: Name: %s", channel_name)
 
             channel_output_name = "output_" + str(channel_name)
+            channel_unit = query['series'][i]['unit']
             if channel_output_name not in sensors:
                 _LOGGER.debug("Out: Creating Channel sensor %s", channel_output_name)
-                sensors[channel_output_name] = Sensor("N/A", outputs[i]['name'], "Output", outputs[i]['units'], None, self._macAddress)
+                sensors[channel_output_name] = Sensor("N/A", channel_name, "Output", channel_unit, None, self._macAddress)
             else:
                 outputsensor = sensors[channel_output_name]
-                outputsensor.setUnit(outputs[i]['units'])
+                outputsensor.setUnit(channel_unit)
                 outputsensor.setSensorID(self._macAddress)
 
 

--- a/iotawattpy/sensor.py
+++ b/iotawattpy/sensor.py
@@ -4,12 +4,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Sensor:
-    def __init__(self, channel, name, io_type, unit, value, mac_addr):
+    def __init__(self, channel, name, io_type, unit, value, begin, mac_addr):
         self._channel = channel
         self._name = name
         self._type = io_type
         self._unit = unit
         self._value = value
+        self._begin = begin
         self._sensor_id = None
 
         self.hub_mac_address = mac_addr
@@ -33,7 +34,7 @@ class Sensor:
 
     def setName(self, name):
         self._name = name
-        
+
     def getType(self):
         return self._type
 
@@ -51,3 +52,9 @@ class Sensor:
 
     def setValue(self, value):
         self._value = value
+
+    def getBegin(self):
+        return self._begin
+
+    def setBegin(self, begin):
+        self._begin = begin

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "httpx==0.16.1"
+        "httpx>=0.16.1"
     ],
     python_requires='>=3.8',
 )

--- a/tests/test_sensorio_getset.py
+++ b/tests/test_sensorio_getset.py
@@ -6,7 +6,7 @@ from iotawattpy.sensor import Sensor  # noqa
 
 @pytest.fixture(scope="session")
 def sensor():
-    sensor = Sensor("", "myname", "Input", "Watts", 102, "deadbeef")
+    sensor = Sensor("", "myname", "Input", "Watts", 102, "2021-01-01", "deadbeef")
     return sensor
 
 


### PR DESCRIPTION
The main aim of this PR is to add energy sensors (in watt-hours) for all inputs and outputs of type power (watts). Using IoTaWatt's to provide energy directly is more accurate than integrating energy on the client side.