### PR TITLE
Removal of sensor causes exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="iotawattpy",
-    version="0.0.6",
+    version="0.0.7",
     author="Greg Diehl",
     author_email="greg.diehl.gtd@gmail.com",
     description="Python library for the IoTaWatt Energy device",


### PR DESCRIPTION
The logic adds sensors when they are created through the IoTaWatt web interface. The logic does not take into account when a sensor is removed from the web interface.

This checks the sensor list in memory to the list coming from the IoTaWatt device, and removes from memory any sensors not found on the IoTaWatt device.
