### PR TITLE
Add energy readout

### DIFF
--- a/example.py
+++ b/example.py
@@ -10,11 +10,10 @@ import httpx
 
 LOOP = asyncio.get_event_loop()
 
-logging.basicConfig(level='DEBUG')
+logging.basicConfig(level="DEBUG")
 
 
 class Tester:
-
     def __init__(self, ip_addr, username, password):
         self._ip_addr = ip_addr
         self._username = username
@@ -22,7 +21,9 @@ class Tester:
 
     async def run(self):
         self.session = AsyncClient()
-        self.iotawatt = Iotawatt("iotawatt", self._ip_addr, self.session, self._username, self._password)
+        self.iotawatt = Iotawatt(
+            "iotawatt", self._ip_addr, self.session, self._username, self._password
+        )
         try:
             await self.iotawatt.connect()
         except httpx.HTTPStatusError as err:
@@ -30,22 +31,24 @@ class Tester:
             await self.session.aclose()
             return
 
-        while(True):
+        while True:
             logging.info("=============================================")
             await self.iotawatt.update()
             logging.info("=============================================")
-            time.sleep(5)            
+            time.sleep(5)
 
 
 def main(argv):
-    my_parser = argparse.ArgumentParser(description='Run the IoTaWatt tester')
-    my_parser.add_argument('IPAddress', metavar='IP Address', type=str, help="IP Address of IoTaWatt")
-    my_parser.add_argument('-u', metavar='Username', type=str, help="Username")
-    my_parser.add_argument('-p', metavar='Password', type=str, help="Password")
+    my_parser = argparse.ArgumentParser(description="Run the IoTaWatt tester")
+    my_parser.add_argument(
+        "IPAddress", metavar="IP Address", type=str, help="IP Address of IoTaWatt"
+    )
+    my_parser.add_argument("-u", metavar="Username", type=str, help="Username")
+    my_parser.add_argument("-p", metavar="Password", type=str, help="Password")
 
     args = my_parser.parse_args()
 
-    logging.info('Started')
+    logging.info("Started")
 
     test = Tester(args.IPAddress, args.u, args.p)
     LOOP.run_until_complete(test.run())

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import json
 import logging
 
@@ -22,12 +24,15 @@ class Iotawatt:
         websession: httpx.AsyncClient,
         username=None,
         password=None,
+        integratedInterval="y",
     ):
         self._device_name = device_name
         self._ip = ip
         self._connection = Connection(websession, self._ip)
         self._username = username
         self._password = password
+        self._integratedInterval = integratedInterval
+        self._lastUpdateTime = None
 
         self._sensors = {}
         self._sensors["sensors"] = {}
@@ -63,11 +68,17 @@ class Iotawatt:
         return self._sensors
 
     """Retrieves sensor data and updates the Sensor objects"""
+
     async def update(self, timespan=30):
         if not self._getMACFlag:
             await self.connect()
             self._getMACFlag = True
         await self._refreshSensors(timespan)
+
+    """Retrieve the last update time"""
+
+    def getLastUpdateTime(self):
+        return self._lastUpdateTime
 
     """Private helper functions"""
 
@@ -77,69 +88,89 @@ class Iotawatt:
         url = "http://{}/status?inputs=yes&outputs=yes".format(self._ip)
         return await self._connection.get(url, self._username, self._password)
 
-    def _createOrUpdateSensor(self, sensors, entity, channel_nbr, name, type, unit):
+    def _createOrUpdateSensor(
+        self,
+        sensors,
+        entity,
+        channel_nbr,
+        base_name,
+        type,
+        unit,
+        suffix="",
+        fromStart=False,
+    ):
         if entity not in sensors:
             LOGGER.debug("%s: Creating Channel sensor %s", type, entity)
-            sensors[entity] = Sensor(channel_nbr, name, type, unit, None, None, self._macAddress)
+            sensors[entity] = Sensor(
+                channel_nbr,
+                base_name,
+                suffix,
+                type,
+                unit,
+                None,
+                None,
+                self._macAddress,
+                fromStart,
+            )
         else:
             sensor = sensors[entity]
-            sensor.setName(name)
+            sensor.setBaseName(base_name)
+            sensor.setSuffix(suffix)
             sensor.setUnit(unit)
             sensor.setSensorID(self._macAddress)
+            sensor.setFromStart(fromStart)
 
-    def _createOrUpdateSensorSet(self, sensors, entity, channel_nbr, name, type, unit):
-        self._createOrUpdateSensor(sensors, entity, channel_nbr, name, type, unit)
+    def _createOrUpdateSensorSet(
+        self, sensors, entity, channel_nbr, base_name, type, unit
+    ):
+        self._createOrUpdateSensor(sensors, entity, channel_nbr, base_name, type, unit)
 
         # Also add Energy sensors (the integral of Power) for all Power sensors
         if unit == "Watts":
-            entity = entity + "_energy"
-            name = name + ".wh"
-            self._createOrUpdateSensor(sensors, entity, channel_nbr, name, type, "WattHours")
-
+            self._createOrUpdateSensor(
+                sensors,
+                entity + "_total_energy",
+                channel_nbr,
+                base_name,
+                type,
+                "WattHours",
+                suffix="wh",
+                fromStart=True,
+            )
+            self._createOrUpdateSensor(
+                sensors,
+                entity + "_energy",
+                channel_nbr,
+                base_name,
+                type,
+                "WattHours",
+                suffix="wh",
+            )
 
     async def _refreshSensors(self, timespan):
-        sensors = self._sensors['sensors']
+        sensors = self._sensors["sensors"]
 
         response = await self._getInputsandOutputs()
         results = response.text
         results = json.loads(results)
         LOGGER.debug("IOResults: %s", results)
-        inputs = results['inputs']
-        outputs = results['outputs']
+        inputs = results["inputs"]
+        outputs = results["outputs"]
 
         query = await self._getQueryShowSeries()
         query = query.text
         query = json.loads(query)
         LOGGER.debug("Query: %s", query)
 
-        for i in range(len(inputs)):
-            channel_nbr = inputs[i]['channel']
-            LOGGER.debug("In: Channel: %s - Name: %s", channel_nbr, query['series'][i]['name'])
-
-            channel_input_name = "input_" + str(channel_nbr)
-            channel_unit = query['series'][i]['unit']
-            self._createOrUpdateSensorSet(sensors, channel_input_name, channel_nbr, query['series'][i]['name'], "Input", channel_unit)
-
-        for i in range(len(outputs)):
-            channel_name = str(outputs[i]['name'])
-            LOGGER.debug("Out: Name: %s", channel_name)
-
-            channel_output_name = "output_" + str(channel_name)
-            channel_unit = outputs[i]['units']
-            self._createOrUpdateSensorSet(sensors, channel_output_name, "N/A", channel_name, "Output", channel_unit)
-
         # Check and remove a sensor if it exists in memory but not from the query
         keys_to_be_removed = []
         LOGGER.debug("SensorKeys: %s", sensors.items())
         for entity, sensor in sensors.items():
             flag = False
-            for i in range(len(query['series'])):
-                if sensor.getUnit() == "WattHours":
-                    queryName = query['series'][i]['name'] + ".wh"
-                else:
-                    queryName = query['series'][i]['name']
+            for i in range(len(query["series"])):
+                queryName = query["series"][i]["name"]
                 LOGGER.debug("Compare: %s - %s", sensor.getName(), queryName)
-                if sensor.getName() == queryName:
+                if sensor.getBaseName() == queryName:
                     flag = True
                     break
                 else:
@@ -149,17 +180,51 @@ class Iotawatt:
                 LOGGER.debug("Adding to be removed: %s", entity)
                 keys_to_be_removed.append(entity)
 
-        if len(keys_to_be_removed) > 0:        
+        if len(keys_to_be_removed) > 0:
             for k in keys_to_be_removed:
                 sensors.pop(k)
             LOGGER.debug("Check entity(s) removed: %s", sensors.items())
-        
+
+        for i in range(len(inputs)):
+            channel_nbr = inputs[i]["channel"]
+            LOGGER.debug(
+                "In: Channel: %s - Name: %s", channel_nbr, query["series"][i]["name"]
+            )
+
+            channel_input_name = "input_" + str(channel_nbr)
+            channel_unit = query["series"][i]["unit"]
+            self._createOrUpdateSensorSet(
+                sensors,
+                channel_input_name,
+                channel_nbr,
+                query["series"][i]["name"],
+                "Input",
+                channel_unit,
+            )
+
+        for i in range(len(outputs)):
+            channel_name = str(outputs[i]["name"])
+            LOGGER.debug("Out: Name: %s", channel_name)
+
+            channel_output_name = "output_" + str(channel_name)
+            channel_unit = outputs[i]["units"]
+            self._createOrUpdateSensorSet(
+                sensors,
+                channel_output_name,
+                "N/A",
+                channel_name,
+                "Output",
+                channel_unit,
+            )
 
         # Update all entities, query depending on Unit
         current_query_entities = []
+        integrated_total_query_entities = []
         integrated_query_entities = []
         for entity, sensor in sensors.items():
-            if sensor.getUnit() == "WattHours":
+            if sensor.getUnit() == "WattHours" and sensor.getFromStart():
+                integrated_total_query_entities.append(entity)
+            elif sensor.getUnit() == "WattHours":
                 integrated_query_entities.append(entity)
             else:
                 current_query_entities.append(entity)
@@ -167,9 +232,13 @@ class Iotawatt:
         # Current (as in right now) measurements
         current_query_names = []
         for entity in current_query_entities:
-            current_query_names.append(f"{sensors[entity].getName()}.{sensors[entity].getUnit().lower()}")
+            current_query_names.append(
+                f"{sensors[entity].getName()}.{sensors[entity].getUnit().lower()}"
+            )
         LOGGER.debug("Sen: %s", current_query_names)
-        response = await self._getQuerySelectSeriesCurrent(current_query_names, timespan)
+        response = await self._getQuerySelectSeriesCurrent(
+            current_query_names, timespan
+        )
         values = json.loads(response.text)
         LOGGER.debug("Val: %s", values)
 
@@ -178,19 +247,67 @@ class Iotawatt:
             sensor = sensors[current_query_entities[idx]]
             sensor.setValue(values[0][idx])
 
-        # Integrated (as in integral) measurements
-        integrated_query_names = [ sensors[entity].getName() for entity in integrated_query_entities ]
-        LOGGER.debug("Sen: %s", integrated_query_names)
-        response = await self._getQuerySelectSeriesIntegrate(integrated_query_names, "y")
+        # Integrated (as in integral) measurements since beginning of period
+        integrated_total_query_names = [
+            sensors[entity].getName() for entity in integrated_total_query_entities
+        ]
+        LOGGER.debug("Sen: %s", integrated_total_query_names)
+        response = await self._getQuerySelectSeriesIntegrate(
+            integrated_total_query_names, self._integratedInterval
+        )
+        values = json.loads(response.text)
+        LOGGER.debug("Val: %s", values)
+
+        # We can assume the same index for integrated_query_entities/integrated_query_names
+        for idx in range(len(integrated_total_query_names)):
+            sensor = sensors[integrated_total_query_entities[idx]]
+            sensor.setValue(values[0][idx + 1])
+            sensor.setBegin(values[0][0])
+
+        # Integrated (as in integral) measurements since last querie of period
+        integrated_query_names = [
+            sensors[entity].getName() for entity in integrated_query_entities
+        ]
+        LOGGER.debug("Sen: %s", integrated_total_query_names)
+        # The iotawatt only know how to deal with either local timezone and UTC timezone.
+        # A local time zone different to the one set on the iotawatt would yield
+        # incorrect result. As a workaround, we use UTC.
+        now = datetime.now(tz=timezone.utc)
+
+        # The iotawatt only supports rounded seconds. We also ound to the nearest 30s
+        seconds = now.second
+        diff = seconds - 30 if seconds >= 30 else seconds
+        now -= timedelta(seconds=diff, microseconds=now.microsecond)
+
+        lastUpdate = (
+            now - timedelta(seconds=timespan)
+            if self._lastUpdateTime is None
+            else self._lastUpdateTime
+        )
+        LOGGER.debug(
+            f"Querying energy at {now.isoformat()} for the past {(now-lastUpdate).seconds}"
+        )
+        if now == lastUpdate:
+            LOGGER.warning(
+                "Nothing to query, update() called too soon, must wait {timespan}"
+            )
+            return
+        response = await self._getQuerySelectSeriesIntegrate(
+            integrated_query_names,
+            lastUpdate.isoformat().split("+")[0] + "Z",
+            now.isoformat().split("+")[0] + "Z",
+            precision=".d3",
+        )
         values = json.loads(response.text)
         LOGGER.debug("Val: %s", values)
 
         # We can assume the same index for integrated_query_entities/integrated_query_names
         for idx in range(len(integrated_query_names)):
             sensor = sensors[integrated_query_entities[idx]]
-            sensor.setValue(values[0][idx+1])
+            sensor.setValue(values[0][idx + 1])
             sensor.setBegin(values[0][0])
 
+        self._lastUpdateTime = now
 
     async def _getQueryShowSeries(self):
         url = "http://{}/query?show=series".format(self._ip)
@@ -209,9 +326,12 @@ class Iotawatt:
         LOGGER.debug("Querying with URL %s", url)
         return await self._connection.get(url, self._username, self._password)
 
-
-    async def _getQuerySelectSeriesIntegrate(self, sensor_names, start):
-        """Get integrated (summed) values using Query API.
+    async def _getQuerySelectSeriesIntegrate(
+        self, sensor_names, start, end="s", group="all", precision=""
+    ):
+        """Get integrated (summed) values using Query API if group is set to "all"
+        or discrete values otherwise; note that the iotawatt is unable to provide more than 100kB
+        of data
 
         @param: sensor_names List of sensors
         @param: start Start time. ISO dates are supported. the following characters can be used as well:
@@ -222,8 +342,10 @@ class Iotawatt:
         See also:https://docs.iotawatt.com/en/02_06_03/query.html#relative-time
         """
         url = "http://{}/query".format(self._ip)
-        strSeries = ",".join(sensor_names)
-        url = url + f"?select=[time.iso,{strSeries}]&begin={start}&end=s&group=all"
+        strSeries = f"{precision},".join(sensor_names) + precision
+        url = (
+            url
+            + f"?select=[time.iso,{strSeries}]&begin={start}&end={end}&group={group}"
+        )
         LOGGER.debug("Querying with URL %s", url)
         return await self._connection.get(url, self._username, self._password)
-

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -96,7 +96,7 @@ class Iotawatt:
         base_name,
         type,
         unit,
-        suffix="",
+        suffix=None,
         fromStart=False,
     ):
         if entity not in sensors:
@@ -134,7 +134,7 @@ class Iotawatt:
                 base_name,
                 type,
                 "WattHours",
-                suffix="wh",
+                suffix=".wh",
                 fromStart=True,
             )
             self._createOrUpdateSensor(
@@ -144,7 +144,7 @@ class Iotawatt:
                 base_name,
                 type,
                 "WattHours",
-                suffix="wh",
+                suffix=".wh",
             )
 
     async def _refreshSensors(self, timespan, lastUpdate):
@@ -169,7 +169,7 @@ class Iotawatt:
             flag = False
             for i in range(len(query["series"])):
                 queryName = query["series"][i]["name"]
-                LOGGER.debug("Compare: %s - %s", sensor.getName(), queryName)
+                LOGGER.debug("Compare: %s (base:%s) - %s", sensor.getName(), sensor.getBaseName(), queryName)
                 if sensor.getBaseName() == queryName:
                     flag = True
                     break
@@ -233,7 +233,7 @@ class Iotawatt:
         current_query_names = []
         for entity in current_query_entities:
             current_query_names.append(
-                f"{sensors[entity].getName()}.{sensors[entity].getUnit().lower()}"
+                f"{sensors[entity].getSourceName()}.{sensors[entity].getUnit().lower()}"
             )
         LOGGER.debug("Sen: %s", current_query_names)
         response = await self._getQuerySelectSeriesCurrent(
@@ -249,7 +249,7 @@ class Iotawatt:
 
         # Integrated (as in integral) measurements since beginning of period
         integrated_total_query_names = [
-            sensors[entity].getName() for entity in integrated_total_query_entities
+            sensors[entity].getSourceName() for entity in integrated_total_query_entities
         ]
         LOGGER.debug("Sen: %s", integrated_total_query_names)
         response = await self._getQuerySelectSeriesIntegrate(
@@ -266,7 +266,7 @@ class Iotawatt:
 
         # Integrated (as in integral) measurements since last querie of period
         integrated_query_names = [
-            sensors[entity].getName() for entity in integrated_query_entities
+            sensors[entity].getSourceName() for entity in integrated_query_entities
         ]
         LOGGER.debug("Sen: %s", integrated_total_query_names)
         # The iotawatt only know how to deal with either local timezone and UTC timezone.

--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -69,11 +69,11 @@ class Iotawatt:
 
     """Retrieves sensor data and updates the Sensor objects"""
 
-    async def update(self, timespan=30):
+    async def update(self, timespan=30, lastUpdate=None):
         if not self._getMACFlag:
             await self.connect()
             self._getMACFlag = True
-        await self._refreshSensors(timespan)
+        await self._refreshSensors(timespan, lastUpdate)
 
     """Retrieve the last update time"""
 
@@ -147,7 +147,7 @@ class Iotawatt:
                 suffix="wh",
             )
 
-    async def _refreshSensors(self, timespan):
+    async def _refreshSensors(self, timespan, lastUpdate):
         sensors = self._sensors["sensors"]
 
         response = await self._getInputsandOutputs()
@@ -279,11 +279,12 @@ class Iotawatt:
         diff = seconds - 30 if seconds >= 30 else seconds
         now -= timedelta(seconds=diff, microseconds=now.microsecond)
 
-        lastUpdate = (
-            now - timedelta(seconds=timespan)
-            if self._lastUpdateTime is None
-            else self._lastUpdateTime
-        )
+        if lastUpdate is None:
+            lastUpdate = (
+                now - timedelta(seconds=timespan)
+                if self._lastUpdateTime is None
+                else self._lastUpdateTime
+            )
         LOGGER.debug(
             f"Querying energy at {now.isoformat()} for the past {(now-lastUpdate).seconds}"
         )

--- a/iotawattpy/sensor.py
+++ b/iotawattpy/sensor.py
@@ -42,8 +42,11 @@ class Sensor:
     def setSensorID(self, hub_mac_address):
         self._sensor_id = hub_mac_address + "_" + self._type + "_" + self.getName()
 
+    def getSourceName(self):
+        return self._base_name + (f"{self._suffix}" if self._suffix != None else "")
+
     def getName(self):
-        return self._base_name + ("." + self._suffix if self._suffix != "" else "")
+        return self.getSourceName() + ("_last" if self._suffix == ".wh" and not self._fromStart else "")
 
     def getBaseName(self):
         return self._base_name

--- a/iotawattpy/sensor.py
+++ b/iotawattpy/sensor.py
@@ -4,14 +4,27 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Sensor:
-    def __init__(self, channel, name, io_type, unit, value, begin, mac_addr):
+    def __init__(
+        self,
+        channel,
+        base_name,
+        suffix,
+        io_type,
+        unit,
+        value,
+        begin,
+        mac_addr,
+        fromStart=False,
+    ):
         self._channel = channel
-        self._name = name
+        self._base_name = base_name
+        self._suffix = suffix
         self._type = io_type
         self._unit = unit
         self._value = value
         self._begin = begin
         self._sensor_id = None
+        self._fromStart = fromStart
 
         self.hub_mac_address = mac_addr
 
@@ -27,13 +40,22 @@ class Sensor:
         return self._sensor_id
 
     def setSensorID(self, hub_mac_address):
-        self._sensor_id = hub_mac_address + "_" + self._type + "_" + self._name
+        self._sensor_id = hub_mac_address + "_" + self._type + "_" + self.getName()
 
     def getName(self):
-        return self._name
+        return self._base_name + ("." + self._suffix if self._suffix != "" else "")
 
-    def setName(self, name):
-        self._name = name
+    def getBaseName(self):
+        return self._base_name
+
+    def setBaseName(self, base_name):
+        self._base_name = base_name
+
+    def getSuffix(self):
+        return self._suffix
+
+    def setSuffix(self, suffix):
+        self._suffix = suffix
 
     def getType(self):
         return self._type
@@ -58,3 +80,9 @@ class Sensor:
 
     def setBegin(self, begin):
         self._begin = begin
+
+    def getFromStart(self):
+        return self._fromStart
+
+    def setFromStart(self, fromStart):
+        self._fromStart = fromStart

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="iotawattpy",
-    version="0.0.9",
+    version="0.1.0",
     author="Greg Diehl",
     author_email="greg.diehl.gtd@gmail.com",
     description="Python library for the IoTaWatt Energy device",
@@ -18,8 +18,6 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
     ],
-    install_requires=[
-        "httpx>=0.16.1"
-    ],
-    python_requires='>=3.8',
+    install_requires=["httpx>=0.16.1"],
+    python_requires=">=3.8",
 )

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath(
-    os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import iotawattpy  # noqa # pylint: disable=unused-import, wrong-import-position

--- a/tests/test_sensorio_getset.py
+++ b/tests/test_sensorio_getset.py
@@ -6,7 +6,7 @@ from iotawattpy.sensor import Sensor  # noqa
 
 @pytest.fixture(scope="session")
 def sensor():
-    sensor = Sensor("", "myname", "Input", "Watts", 102, "2021-01-01", "deadbeef")
+    sensor = Sensor("", "myname", "", "Input", "Watts", 102, "2021-01-01", "deadbeef")
     return sensor
 
 


### PR DESCRIPTION
Due to how the iotawatt execute queries, it's unsuitable for using with outputs based on mathematical expressions other than those using + and - (such as defined for calculating export and import)

Report the energy used since last queried in Wh. This value should be added to the previous reads

Add an option to set when to fetch the energy data from (can be set from the beginning of the month, the day etc) and to retrieve the data at a given time (useful when first syncing or the client has been disconnected for a while)

Apply black formatting.

Bump version to 0.1.0.