### PR TITLE
Change time interval rounding to 5s

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -274,9 +274,10 @@ class Iotawatt:
         # incorrect result. As a workaround, we use UTC.
         now = datetime.now(tz=timezone.utc)
 
-        # The iotawatt only supports rounded seconds. We also ound to the nearest 30s
+        # The iotawatt only supports rounded seconds. We also round to the nearest 5s,
+        # iotawatt's measurement interval.
         seconds = now.second
-        diff = seconds - 30 if seconds >= 30 else seconds
+        diff = seconds % 5
         now -= timedelta(seconds=diff, microseconds=now.microsecond)
 
         if lastUpdate is None:


### PR DESCRIPTION
Change time interval rounding to 5s which matches iotawatts data log interval. See https://docs.iotawatt.com/en/master/query.html. This allows client to request data more frequently then every 30s.