### PR TITLE
Add None checking in refresh sensors

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -151,6 +151,9 @@ class Iotawatt:
         sensors = self._sensors["sensors"]
 
         response = await self._getInputsandOutputs()
+        if response is None:
+            LOGGER.warn("Received None for inputs and outputs")
+            return
         results = response.text
         results = json.loads(results)
         LOGGER.debug("IOResults: %s", results)
@@ -158,6 +161,9 @@ class Iotawatt:
         outputs = results["outputs"]
 
         query = await self._getQueryShowSeries()
+        if query is None:
+            LOGGER.warn("Received None for query")
+            return
         query = query.text
         query = json.loads(query)
         LOGGER.debug("Query: %s", query)


### PR DESCRIPTION
I think this should help with the issue reported here https://github.com/gtdiehl/iotawattpy/issues/6. I have seen similar issues on my homeassistant install as well.

'NoneType' object has no attribute 'text'
Traceback (most recent call last):
  File "/srv/homeassistant/lib64/python3.9/site-packages/homeassistant/helpers/update_coordinator.py", line 187, in _async_refresh
    self.data = await self._async_update_data()
  File "/srv/homeassistant/lib64/python3.9/site-packages/homeassistant/components/iotawatt/coordinator.py", line 65, in _async_update_data
    await self.api.update(lastUpdate=self._last_run)
  File "/srv/homeassistant/lib64/python3.9/site-packages/iotawattpy/iotawatt.py", line 76, in update
    await self._refreshSensors(timespan, lastUpdate)
  File "/srv/homeassistant/lib64/python3.9/site-packages/iotawattpy/iotawatt.py", line 154, in _refreshSensors
    results = response.text
AttributeError: 'NoneType' object has no attribute 'text'