### PR TITLE
iotawatt: add getConfiguration() method

### DIFF
--- a/iotawattpy/iotawatt.py
+++ b/iotawattpy/iotawatt.py
@@ -80,6 +80,18 @@ class Iotawatt:
     def getLastUpdateTime(self):
         return self._lastUpdateTime
 
+    """Retrieves the configuration from the IoTaWatt"""
+
+    async def getConfiguration(self):
+        url = "http://{}/config.txt".format(self._ip)
+        response = await self._connection.get(url, self._username, self._password)
+        if response.status_code != httpx.codes.OK:
+            results.raise_for_status()
+
+        results = response.text
+        results = json.loads(results)
+        return results
+
     """Private helper functions"""
 
     """Retrieves list of Inputs and Outputs and associated Status from the IoTaWatt"""


### PR DESCRIPTION
I'd like to be able to fetch the configuration for the IoTaWatt in addition to the sensor values (e.g. to be able to display the script used to generate an output, or for backing up the configuration). This PR adds that functionality, by adding a method `getConfiguration` which returns the JSON-decoded configuration from the IoTaWatt.